### PR TITLE
feat: 착용 이력 저장 API 구현 및 관련 DB 구조 추가

### DIFF
--- a/prisma/migrations/20260111135940_update_user_schema/migration.sql
+++ b/prisma/migrations/20260111135940_update_user_schema/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `birthDate` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "birthDate" SET NOT NULL;

--- a/prisma/migrations/20260128084057_sync_local_with_dev/migration.sql
+++ b/prisma/migrations/20260128084057_sync_local_with_dev/migration.sql
@@ -1,0 +1,45 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `categorySub_id` on the `Clothing` table. All the data in the column will be lost.
+  - You are about to drop the column `color` on the `Clothing` table. All the data in the column will be lost.
+  - You are about to drop the column `season` on the `Clothing` table. All the data in the column will be lost.
+  - You are about to drop the `CategoryMain` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `CategorySub` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `category_id` to the `Clothing` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "CategorySub" DROP CONSTRAINT "CategorySub_categoryMain_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Clothing" DROP CONSTRAINT "Clothing_categorySub_id_fkey";
+
+-- AlterTable
+ALTER TABLE "Clothing" DROP COLUMN "categorySub_id",
+DROP COLUMN "color",
+DROP COLUMN "season",
+ADD COLUMN     "category_id" INTEGER NOT NULL;
+
+-- DropTable
+DROP TABLE "CategoryMain";
+
+-- DropTable
+DROP TABLE "CategorySub";
+
+-- DropEnum
+DROP TYPE "Color";
+
+-- DropEnum
+DROP TYPE "Season";
+
+-- CreateTable
+CREATE TABLE "Category" (
+    "category_id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Category_pkey" PRIMARY KEY ("category_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Clothing" ADD CONSTRAINT "Clothing_category_id_fkey" FOREIGN KEY ("category_id") REFERENCES "Category"("category_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260128092159_add_wear_record_features/migration.sql
+++ b/prisma/migrations/20260128092159_add_wear_record_features/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `outfit_name` on the `Outfit` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Date" ADD COLUMN     "memo" TEXT;
+
+-- AlterTable
+ALTER TABLE "Outfit" DROP COLUMN "outfit_name",
+ADD COLUMN     "is_heart" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "is_star" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -158,7 +158,8 @@ model Clothing {
 model Outfit {
   outfit_id   Int      @id @default(autoincrement())
   user_id     Int
-  outfit_name String
+  is_heart    Boolean       @default(false)
+  is_star     Boolean       @default(false)
   created_at  DateTime @default(now())
 
   user         User          @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
@@ -184,6 +185,7 @@ model Date {
   outfit_id Int
   wear_date DateTime
   user_id   Int
+  memo      String?  @db.Text
 
   outfit Outfit @relation(fields: [outfit_id], references: [outfit_id], onDelete: Cascade)
   user   User   @relation(fields: [user_id], references: [user_id], onDelete: Cascade)

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import authRoutes from "./routes/auth";
 import closetRoutes from "./routes/closet";
 import uploadRoutes from "./routes/upload";
 import outfitRoutes from "./routes/outfit";
+import wearRecordRoutes from "./routes/wear-record.route"
 
 const app = express();
 
@@ -235,6 +236,7 @@ app.use("/api/auth", authRoutes); // 모든 auth 관련 API는 /api/auth로 시�
 app.use("/api/closet", closetRoutes); // 모든 closet 관련 API는 /api/closet로 시작함
 app.use("/api/upload", uploadRoutes); // 모든 upload 관련 API는 /api/upload로 시작함
 app.use("/api/outfit", outfitRoutes); // 모든 outfit 관련 API는 /api/outfit로 시작함
+app.use("/api/v1/wear-records", wearRecordRoutes);
 
 app.listen(4000, () =>
   console.log("🚀 Server running on http://localhost:4000"),

--- a/src/controllers/wear-record.controller.ts
+++ b/src/controllers/wear-record.controller.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from "express";
+import * as wearRecordService from "../services/wear-record.service";
+import { CreateWearRecordRequestDto } from "../dtos/wear-record.dto";
+
+export const postWearRecord = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    // 1. 인증 미들웨어에서 넣어준 유저 정보 가져오기 (req.user 구조 확인 필요)
+    const userId = (req as any).user.user_id; 
+    const body: CreateWearRecordRequestDto = req.body;
+
+    // 2. 간단한 유효성 검사
+    if (!body.clothes_ids || body.clothes_ids.length === 0) {
+        return res.status(400).json({
+            success: false,
+            message: "선택된 옷이 없습니다.",
+            error: "EMPTY_CLOTHES_LIST"
+        });
+    }
+
+    // 3. 서비스 호출
+    const result = await wearRecordService.saveWearRecord(userId, body);
+
+    // 4. 성공 응답
+    return res.status(200).json({
+      success: true,
+      data: result,
+      error: null
+    });
+  } catch (error: any) {
+    console.error("착용 이력 저장 API 에러:", error);
+    
+    return res.status(500).json({
+      success: false,
+      message: "기록 정보를 저장할 수 없습니다.",
+      error: "SERVER_ERROR"
+    });
+  }
+};

--- a/src/dtos/wear-record.dto.ts
+++ b/src/dtos/wear-record.dto.ts
@@ -1,0 +1,14 @@
+// 착용 이력 저장 요청 DTO (POST api/v1/wear-records)
+export interface CreateWearRecordRequestDto {
+  wear_date: string;       // "YYYY-MM-DD"
+  clothes_ids: number[];   // 선택한 옷들의 ID 리스트
+  memo?: string;           // 선택 사항 (코디 메모)
+  is_heart?: boolean;      // 하트 표시 여부 (기본값 false)
+  is_star?: boolean;       // 즐겨찾기 표시 여부 (기본값 false)
+}
+
+// 착용 이력 저장 응답 DTO
+export interface CreateWearRecordResponseDto {
+  date_id: number;         // Date 테이블 PK
+  outfit_id: number;       // Outfit 테이블 PK
+}

--- a/src/repositories/wear-record.repository.ts
+++ b/src/repositories/wear-record.repository.ts
@@ -1,0 +1,49 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient(); // 보통 repository에서 한 번만 선언합니다.
+
+// 기존에 같은 옷 조합이 있는지 확인
+export const findExistingOutfit = async (userId: number, clothesIds: number[]) => {
+    const outfits = await prisma.outfit.findMany({
+        where: { user_id: userId },
+        include: { outfitCloths: true },
+    });
+
+    return outfits.find(outfit => {
+        const ids = outfit.outfitCloths.map(oc => oc.clothing_id).sort();
+        return JSON.stringify(ids) === JSON.stringify([...clothesIds].sort());
+    });
+};
+
+// 새로운 코디 생성
+export const createOutfitWithClothes = async (userId: number, clothesIds: number[], isHeart: boolean, isStar: boolean) => {
+    return await prisma.outfit.create({
+        data: {
+            user_id: userId,
+            is_heart: isHeart,
+            is_star: isStar,
+            outfitCloths: {
+                create: clothesIds.map(id => ({ clothing_id: id }))
+            }
+        }
+    });
+};
+
+// 기존 코디 상태 업데이트 (하트, 별)
+export const updateOutfitStatus = async (outfitId: number, isHeart: boolean, isStar: boolean) => {
+    return await prisma.outfit.update({
+        where: { outfit_id: outfitId },
+        data: { is_heart: isHeart, is_star: isStar }
+    });
+};
+
+// 착용 날짜 기록 저장
+export const createWearDateRecord = async (userId: number, outfitId: number, wearDate: string, memo?: string) => {
+    return await prisma.date.create({
+        data: {
+            user_id: userId,
+            outfit_id: outfitId,
+            wear_date: new Date(wearDate),
+            memo: memo || null
+        }
+    });
+};

--- a/src/routes/wear-record.route.ts
+++ b/src/routes/wear-record.route.ts
@@ -1,0 +1,83 @@
+import { Router } from "express";
+import * as wearRecordController from "../controllers/wear-record.controller";
+import { authenticateToken } from "../middlewares/auth";
+
+const router = Router();
+
+/**
+ * @swagger
+ * /api/v1/wear-records:
+ *   post:
+ *     summary: 착용 이력 저장
+ *     description: 사용자가 입은 옷 조합을 코디(Outfit)로 등록하고, 해당 날짜의 착용 기록(Date)을 생성합니다.
+ *     tags: [WearRecord]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - wear_date
+ *               - clothes_ids
+ *             properties:
+ *               wear_date:
+ *                 type: string
+ *                 format: date
+ *                 example: "2026-01-28"
+ *                 description: "YYYY-MM-DD 형식의 착용 날짜"
+ *               clothes_ids:
+ *                 type: array
+ *                 items:
+ *                   type: integer
+ *                 example: [1, 2, 5]
+ *                 description: "착용 이력에 포함될 옷 PK 리스트"
+ *               memo:
+ *                 type: string
+ *                 nullable: true
+ *                 example: "오늘 면접 합격! 날씨가 생각보다 쌀쌀했음."
+ *               is_heart:
+ *                 type: boolean
+ *                 default: false
+ *                 example: true
+ *               is_star:
+ *                 type: boolean
+ *                 default: false
+ *                 example: false
+ *     responses:
+ *       200:
+ *         description: 착용 이력 저장 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     date_id:
+ *                       type: integer
+ *                       example: 999
+ *                     outfit_id:
+ *                       type: integer
+ *                       example: 777
+ *                 error:
+ *                   type: "null"
+ *                   example: null
+ *       400:
+ *         description: 잘못된 요청 (옷 ID 누락 등)
+ *       401:
+ *         description: 인증 실패 (토큰 오류)
+ *       500:
+ *         description: 서버 오류
+ */
+router.post("/", authenticateToken, wearRecordController.postWearRecord);
+
+console.log("✓ Wear-record router initialized");
+
+export default router;

--- a/src/services/wear-record.service.ts
+++ b/src/services/wear-record.service.ts
@@ -1,0 +1,40 @@
+import * as wearRecordRepository from "../repositories/wear-record.repository";
+import { CreateWearRecordRequestDto, CreateWearRecordResponseDto } from "../dtos/wear-record.dto";
+
+export const saveWearRecord = async (
+    userId: number,
+    data: CreateWearRecordRequestDto
+): Promise<CreateWearRecordResponseDto> => {
+    
+    // 1. 기존 조합 확인
+    let outfit = await wearRecordRepository.findExistingOutfit(userId, data.clothes_ids);
+
+    let outfitId: number;
+    if (outfit) {
+        outfitId = outfit.outfit_id;
+        // 상태 업데이트
+        await wearRecordRepository.updateOutfitStatus(outfitId, data.is_heart || false, data.is_star || false);
+    } else {
+        // 2. 새 조합 생성
+        const newOutfit = await wearRecordRepository.createOutfitWithClothes(
+            userId, 
+            data.clothes_ids, 
+            data.is_heart || false, 
+            data.is_star || false
+        );
+        outfitId = newOutfit.outfit_id;
+    }
+
+    // 3. 기록 저장
+    const dateRecord = await wearRecordRepository.createWearDateRecord(
+        userId,
+        outfitId,
+        data.wear_date,
+        data.memo
+    );
+
+    return {
+        date_id: dateRecord.date_id,
+        outfit_id: outfitId
+    };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2020"],
     "types": ["node"],
     
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "outDir": "./dist",
     "rootDir": "./src",
     


### PR DESCRIPTION
<!-- ✨ PR 제목 예시 -->
<!-- feat: 로그인 API 구현 -->
<!-- fix: Clothing 테이블 수정 -->

## 🔗 관련 이슈
- Issue: #28 

## 🌿 작업 브랜치
- Branch: `feat/28-wear-records-api`

## 👩‍💻 작업 내용
**1. 데이터베이스 스키마 설계 및 반영**
- Outfit 모델 개선: outfit_name 필드를 제거하고,  is_heart(좋아요), is_star(즐겨찾기) 필드를 추가했습니다.

- Date 모델 확장: 착용 기록 시 사용자 메모를 남길 수 있도록 memo 필드를 추가했습니다.

- Prisma Migration: 변경된 스키마를 Supabase DB에 반영 완료했습니다. (add_wear_record_features)

**2. 착용 이력 저장 API 구현** (POST /api/v1/wear-records)

## ✅ PR 체크리스트
- [x] 팀의 코딩 스타일 가이드를 준수했습니다.
- [x] 변경 사항에 대한 테스트를 마쳤습니다. (Local Test 완료)
- [x] 새로운 환경 변수가 있다면 팀원들에게 공유했습니다. (예: .env 수정)
- [x] Merge 하려는 브랜치가 올바른지 확인했습니다. (예: feat -> dev)